### PR TITLE
posts.showと_post_commnets.html.erbの修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -12,10 +12,6 @@ class PostsController < ApplicationController
     @comment = @post.comments.build(user_id: current_user.id, post_id: @post.id) if current_user
   end
 
-  def show
-    
-  end
-
   def new
     @post = Post.new
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,7 @@
 class PostsController < ApplicationController
+  before_action :set_post, except: [:index, :new, :create]
   before_action :authenticate_user!, except: [:index, :show]
   before_action :authenticate_admin!, only: [:edit, :update, :destroy]
-  before_action :set_post, except: [:index, :new]
 
   def index
     @posts = Post.includes(:user).all.order("created_at DESC")
@@ -50,8 +50,6 @@ class PostsController < ApplicationController
     end
 
     def authenticate_admin!
-      @post = Post.find(params[:id])
-      
       if @post.user_id != current_user.id
         flash[:notice] = "権限はありません"
         redirect_to root_url

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,13 +1,13 @@
 class PostsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :authenticate_admin!, only: [:edit, :update, :destroy]
+  before_action :set_post, except: [:index, :new]
 
   def index
     @posts = Post.includes(:user).all.order("created_at DESC")
   end
 
   def show
-    @post = Post.find(params[:id])
     @comments = @post.comments.includes(:user).order("created_at DESC")
     @comment = @post.comments.build(user_id: current_user.id, post_id: @post.id) if current_user
   end
@@ -56,6 +56,10 @@ class PostsController < ApplicationController
         flash[:notice] = "権限はありません"
         redirect_to root_url
       end
+    end
+
+    def set_post
+      @post = Post.find(params[:id])
     end
 end
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,1 +1,49 @@
-<%= render 'shared/post_comments' %>
+<div class="post_wrapper">
+  <div class="post_wrapper__header">
+    <h3>
+      <span>投稿詳細</span>
+    </h3>
+    <div class="back_link">
+      <%= link_to root_path do%>
+        <i class="fas fa-angle-double-left"></i>
+        <span>一覧へ戻る</span>
+      <% end %>
+    </div>
+  </div>
+  <div class="post_wrapper__content scroll">
+    <div class="post_wrapper__content__post_show">
+      <div class="post_detail">
+        <div class="post_detail__top_box">
+          <div class="post_detail__top_box__name">
+            <span>投稿者：<%= @post.user.name %></span>
+          </div>
+          <div class="post_detail__top_box__name">
+            <span>投稿日時：<%= @post.created_at.to_s(:datetime_jp)%></span>
+          </div>
+        </div>  
+        <div class="post_detail__middle_box">
+          <span><%= @post.content %></span>
+        </div>
+        <div class="post_detail__bottom_box">
+          <ul class="post_detail__bottom_box__user_actions">
+            <li>
+              <i class="far fa-comment-alt"></i>
+              <span><%= @post.comments.count %></span>
+            </li>
+            <li>
+              <i class="far fa-heart"></i>
+              <span>1</span>
+            </li>
+          </ul>
+          <% if user_signed_in? && @post.user_id == current_user.id %>
+            <div class="post_detail__bottom_box__admin_actions">
+              <%= link_to "編集", edit_post_path(@post.id) %>
+              <%= link_to "削除", @post, method: :delete, data: { confirm: '本当に削除して良いですか?', cancel: 'やめる', commit: '削除する'}, title: '削除確認' %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+    <%= render 'shared/post_comments' %>
+  </div>
+</div>

--- a/app/views/shared/_post_comments.html.erb
+++ b/app/views/shared/_post_comments.html.erb
@@ -1,84 +1,36 @@
-<div class="post_wrapper">
-  <div class="post_wrapper__header">
-    <h3>
-      <span>投稿詳細</span>
-    </h3>
-    <div class="back_link">
-      <%= link_to root_path do%>
-        <i class="fas fa-angle-double-left"></i>
-        <span>一覧へ戻る</span>
-      <% end %>
-    </div>
-  </div>
-  <div class="post_wrapper__content scroll">
-    <div class="post_wrapper__content__post_show">
-      <div class="post_detail">
-        <div class="post_detail__top_box">
-          <div class="post_detail__top_box__name">
-            <span>投稿者：<%= @post.user.name %></span>
-          </div>
-          <div class="post_detail__top_box__name">
-            <span>投稿日時：<%= @post.created_at.to_s(:datetime_jp)%></span>
-          </div>
-        </div>  
-        <div class="post_detail__middle_box">
-          <span><%= @post.content %></span>
+<div class="comment_area">
+  <ul class="comment_area__list">
+    <% @comments.each do |comment| %>
+      <li class="comment_area__list__comment">
+        <div class="comment_area__list__comment__left_box">
+          <span><%= comment.user.name %></span>
         </div>
-        <div class="post_detail__bottom_box">
-          <ul class="post_detail__bottom_box__user_actions">
-            <li>
-              <i class="far fa-comment-alt"></i>
-              <span><%= @post.comments.count %></span>
-            </li>
-            <li>
-              <i class="far fa-heart"></i>
-              <span>1</span>
-            </li>
-          </ul>
-          <% if user_signed_in? && @post.user_id == current_user.id %>
-            <div class="post_detail__bottom_box__admin_actions">
-              <%= link_to "編集", edit_post_path(@post.id) %>
-              <%= link_to "削除", @post, method: :delete, data: { confirm: '本当に削除して良いですか?', cancel: 'やめる', commit: '削除する'}, title: '削除確認' %>
-            </div>
-          <% end %>
+        <div class="comment_area__list__comment__right_box">
+          <div class="comment_area__list__comment__right_box__info">
+            <% if user_signed_in? && comment.user_id == current_user.id %>
+              <span><%= link_to "編集", edit_post_comment_path(@post.id, comment.id) %></span>
+              <span><%= link_to "削除", post_comment_path(@post, comment), method: :delete, data: { confirm: '本当に削除して良いですか?', cancel: 'やめる', commit: '削除する'}, title: '削除確認' %></span>
+            <% end %>
+            <span>投稿日時：<%= comment.created_at.to_s(:datetime_jp) %></span>
+          </div>
+          <div class="comment_area__list__comment__right_box__text">
+            <span><%= comment.comment %></span>
+          </div>
         </div>
-      </div>
-    </div>
-    <div class="comment_area">
-      <ul class="comment_area__list">
-        <% @comments.each do |comment| %>
-          <li class="comment_area__list__comment">
-            <div class="comment_area__list__comment__left_box">
-              <span><%= comment.user.name %></span>
-            </div>
-            <div class="comment_area__list__comment__right_box">
-              <div class="comment_area__list__comment__right_box__info">
-                <% if user_signed_in? && comment.user_id == current_user.id %>
-                  <span><%= link_to "編集", edit_post_comment_path(@post.id, comment.id) %></span>
-                  <span><%= link_to "削除", post_comment_path(@post, comment), method: :delete, data: { confirm: '本当に削除して良いですか?', cancel: 'やめる', commit: '削除する'}, title: '削除確認' %></span>
-                <% end %>
-                <span>投稿日時：<%= comment.created_at.to_s(:datetime_jp) %></span>
-              </div>
-              <div class="comment_area__list__comment__right_box__text">
-                <span><%= comment.comment %></span>
-              </div>
-            </div>
-          </li>
-        <% end %>
-      </ul>
-      <% if user_signed_in? %>
-        <div class="comment_area__form_box">
-          <%= form_with(model:[@post, @comment], class: "comment_area__form_box__form", local: true) do |f| %>
-            <%= render 'shared/error_messages', object: f.object %>
-            <div class="comment_area__form_box__form__field">
-              <%= f.text_area :comment, placeholder: 'コメントを入力', value: @comment.comment %>
-            </div>
-            <div class="comment_area__form_box__form__action">
-              <%= f.submit "送信", class: "comment_area__form_box__form__action__btn" %>
-            </div>
-          <% end %>
+      </li>
+    <% end %>
+  </ul>
+  <% if user_signed_in? %>
+    <div class="comment_area__form_box">
+      <%= form_with(model:[@post, @comment], class: "comment_area__form_box__form", local: true) do |f| %>
+        <%= render 'shared/error_messages', object: f.object %>
+        <div class="comment_area__form_box__form__field">
+          <%= f.text_area :comment, placeholder: 'コメントを入力', value: @comment.comment %>
+        </div>
+        <div class="comment_area__form_box__form__action">
+          <%= f.submit "送信", class: "comment_area__form_box__form__action__btn" %>
         </div>
       <% end %>
     </div>
-  </div>
+  <% end %>
 </div>


### PR DESCRIPTION
# 何か？
- posts.showのメソッドが重複しており、エラーが発生。一方を削除して改善
```
  def show
    @post = Post.find(params[:id])
    @comments = @post.comments.includes(:user).order("created_at DESC")
    @comment = @post.comments.build(user_id: current_user.id, post_id: @post.id) if current_user
  end

  def show
  end
```
- show.html.erbの記述がすべて_post_comments.html.erbに移行されたが、部分テンプレートの意味がないため、コメントに関するhtmlだけ残し、他はshow.html.erbに移行させた。

変更前はこの1行のみ

```show.html.erb
<%= render 'shared/post_comments' %> 
```

変更後はcommentの箇所にrenderを配置

```show.html.erb
          </ul>
          <% if user_signed_in? && @post.user_id == current_user.id %>
            <div class="post_detail__bottom_box__admin_actions">
              <%= link_to "編集", edit_post_path(@post.id) %>
              <%= link_to "削除", @post, method: :delete, data: { confirm: '本当に削除して良いですか?', cancel: 'やめる', commit: '削除する'}, title: '削除確認' %>
            </div>
          <% end %>
        </div>
      </div>
    </div>
    <%= render 'shared/post_comments' %>
  </div>
</div> 
```
## 変更されたファイル
- posts_controller.rb
- show.html.erb
- _post_comments.html.erb